### PR TITLE
Fix error on get server config

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -89,6 +89,8 @@ function createWindow(port, lang) {
     mainWindow.webContents.send('serverStart', { port, lang })
   });
 
+  ipcMain.handle('getConfig', () => ({ port, lang }))
+
   mainWindow.on('closed', () => {
     mainWindow = null;
   });

--- a/src/renderer/app.ts
+++ b/src/renderer/app.ts
@@ -5,6 +5,7 @@ if(window && !window.electronApi){
         setLang: ()=>{},
         changeLang: ()=>{},
         serverState: ()=>{},
+        getConfig: ()=>{},
         statSync: ()=>{},
         isFile: ()=>{},
         basename: ()=>{},
@@ -15,4 +16,4 @@ if(window && !window.electronApi){
 }
 
 
- 
+

--- a/src/renderer/pages/index.js
+++ b/src/renderer/pages/index.js
@@ -25,15 +25,17 @@ const Index = (props) => {
 
   useEffect(() => {
     const lang = getLocale()
-    const { setLang, changeLang, serverState } = window.electronApi
+    const { setLang, changeLang, getConfig } = window.electronApi
     setLang(lang)
     changeLang((event, arg) => {
       setLocale(arg, false);
       window.localStorage.setItem('usl', true)
     })
-    serverState((event, arg) => {
+    const getServerConfig = async () => {
+      const arg = await getConfig()
       window.localStorage.setItem('serverConfig', JSON.stringify(arg))
-    })
+    };
+    getServerConfig()
   }, []);
 
   const saveFile = async (filePath) => {

--- a/src/renderer/public/preload.js
+++ b/src/renderer/public/preload.js
@@ -9,6 +9,7 @@ contextBridge.exposeInMainWorld('electronApi', {
     setLang: (lang) => ipcRenderer.sendSync('syncLanguage', lang),
     changeLang: (cb) => ipcRenderer.on('mainChangeLanguage', cb),
     serverState: (cb) => ipcRenderer.on('serverStart', cb),
+    getConfig: () => ipcRenderer.invoke('getConfig'),
     statSync: (filePath) => fs.statSync(filePath),
     isFile: (filePath) => fs.statSync(filePath).isFile(),
     basename: (filePath) => path.basename(filePath),


### PR DESCRIPTION
解决端口不显示问题。

原方法在启动监听时(`serverState`调用时)，`mainWindow.webContents.send('serverStart', { port, lang })` 这一句已经先执行过了  

![2151672909525_ pic](https://user-images.githubusercontent.com/5575340/210743425-e17db57a-ca87-482b-860a-8a6d0c23153d.jpg)
